### PR TITLE
Upgrade guava from 30.0-jre to 30.1-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,6 +14,6 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 
 version.com.github.spotbugs..spotbugs-annotations=4.2.0
 
-version.com.google.guava..guava=30.0-jre
+version.com.google.guava..guava=30.1-jre
 
 version.junit.junit=4.13.1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.