### PR TITLE
Upgrade junit from 4.13.1 to 4.13.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -16,4 +16,4 @@ version.com.github.spotbugs..spotbugs-annotations=4.2.1
 
 version.com.google.guava..guava=30.1-jre
 
-version.junit.junit=4.13.1
+version.junit.junit=4.13.2


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.